### PR TITLE
PERF: Optimize SnakeCaseNamingPolicy.cs

### DIFF
--- a/src/BusyBox.AspNetCore/Json/SnakeCaseNamingPolicy.cs
+++ b/src/BusyBox.AspNetCore/Json/SnakeCaseNamingPolicy.cs
@@ -23,28 +23,27 @@ namespace BusyBox.AspNetCore.Json
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
 
-            ReadOnlySpan<char> charset = name.ToCharArray();
-            int countCharUpper = GetCountCharUpper(charset);
+            int countCharUpper = GetCountCharUpper(name);
 
             int indexWrite = indexStart;
 
             var arrayPool = ArrayPool<char>.Shared;
-            char[] buffer = arrayPool.Rent(charset.Length + countCharUpper);
+            char[] buffer = arrayPool.Rent(name.Length + countCharUpper);
 
-            if (char.IsUpper(charset[0]))
-                buffer[0] = char.ToLower(charset[0]);
+            if (char.IsUpper(name[0]))
+                buffer[0] = char.ToLower(name[0]);
 
-            for (int indexRead = indexStart; indexRead < charset.Length; indexRead++)
+            for (int indexRead = indexStart; indexRead < name.Length; indexRead++)
             {
-                if (char.IsUpper(charset[indexRead]))
+                if (char.IsUpper(name[indexRead]))
                 {
                     buffer[indexWrite] = splitChar;
-                    buffer[++indexWrite] = char.ToLower(charset[indexRead]);
+                    buffer[++indexWrite] = char.ToLower(name[indexRead]);
                     indexWrite++;
                 }
                 else
                 {
-                    buffer[indexWrite] = charset[indexRead];
+                    buffer[indexWrite] = name[indexRead];
                     indexWrite++;
                 }
             }
@@ -53,6 +52,18 @@ namespace BusyBox.AspNetCore.Json
             arrayPool.Return(buffer, true);
 
             return str;
+        }
+
+        private static int GetCountCharUpper(string str)
+        {
+            int count = 0;
+            for (int index = 0; index < str.Length; index++)
+            {
+                if (char.IsUpper(str[index]))
+                    count++;
+            }
+
+            return count;
         }
 
         private static int GetCountCharUpper(ReadOnlySpan<char> span)


### PR DESCRIPTION
Hi @iigoshkin, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|          Method |         PropertyName |        Mean |     Error |      StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |--------------------- |------------:|----------:|------------:|------------:|-------:|------:|------:|----------:|
| ShakeCaseNaming | HFfw(...)rnHZ [1000] | 22,242.8 ns | 668.02 ns | 1,884.17 ns | 21,560.0 ns | 2.4414 |     - |     - |    5112 B |
| ShakeCaseNaming |  OXgX(...)DtiE [100] |  1,361.5 ns |  25.72 ns |    36.06 ns |  1,355.9 ns | 0.2670 |     - |     - |     560 B |
| ShakeCaseNaming |           lpncKcuWxN |    187.1 ns |   7.39 ns |    21.44 ns |    184.4 ns | 0.0572 |     - |     - |     120 B |

**Benchmarks after changes:**
|          Method |         PropertyName |        Mean |     Error |      StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |--------------------- |------------:|----------:|------------:|------------:|-------:|------:|------:|----------:|
| ShakeCaseNaming | HFfw(...)rnHZ [1000] | 17,668.9 ns | 501.31 ns | 1,454.40 ns | 17,083.0 ns | 1.4648 |     - |     - |    3088 B |
| ShakeCaseNaming |  OXgX(...)DtiE [100] |  1,188.3 ns |  13.17 ns |    11.67 ns |  1,186.9 ns | 0.1602 |     - |     - |     336 B |
| ShakeCaseNaming |           lpncKcuWxN |    171.1 ns |   6.63 ns |    19.33 ns |    164.2 ns | 0.0343 |     - |     - |      72 B |

As you can see the allocations and benchmark durations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!